### PR TITLE
Add IPv6, split permissions, simplify rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,36 @@ Follow the instructions and additionally setup your registar to point to Google 
 ### Grant `cloudbuild` IAM Role permissions
 In the console under IAM & Admin > IAM [here](https://console.cloud.google.com/iam-admin/iam), you should have a member for cloudbuild, something like `123456789@cloudbuild.gserviceaccount.com`.  
 The member account should already have the `Cloud Build Service Account` role.  
-Additionally, create a new custom role that has these permissions:  
+To allow cloud build to modify the loadbalancer configuration, create the following custom role and add it to the cloud build service account.
+
+Role: LoadBalancer certificate updates
 ```
+compute.globalOperations.get
 compute.sslCertificates.create
 compute.sslCertificates.get
 compute.sslCertificates.list
 compute.targetHttpsProxies.get
 compute.targetHttpsProxies.list
 compute.targetHttpsProxies.setSslCertificates
+```
+
+In order to (separately) allow CertBot to alter the zone files in the process of DNS validation, we'll need the following addional role.
+Role: CertBot DNS ownership validation
+```
 dns.changes.create
 dns.changes.get
-dns.changes.list
-dns.managedZones.get
 dns.managedZones.list
-dns.projects.get
 dns.resourceRecordSets.create
 dns.resourceRecordSets.delete
 dns.resourceRecordSets.list
 dns.resourceRecordSets.update
 ```
+While we should be able to just add the above role to the cloud build service account as well, a bug somewhere makes CertBot insensitve to such additions.
+Instead we'll need to provide CertBot with an service account key explicitly, thoudh a json file.
+So, create a new service account, for example 'sa-certbot', and grant it the above role. Also generate a json key for it, this is what we'll use. 
+The easiest way to provide the build system access to the key (security alert) is to include the json file directly into the (cloned) repository.
+Note that this is a workaround, that may no longer be necessary in the near future, as the CertBot team could solve the 'insensitivity'.
+
 You can do this in the console under IAM & Admin > Roles [here](https://console.cloud.google.com/iam-admin/roles)  
 Add your new custom role to the cloudbuild member.
 
@@ -73,7 +84,9 @@ Set the Build Configuration option to `cloudbuild.yaml` and add these additional
 | _CACHE_BUCKET | my-cert-bucket | The name of the Google Cloud Storage bucket to use for storing/retrieving the certificates between builds |
 | _EMAIL | me@example.com | The email that will be used when generating your letsencrypt certificates |
 | _DOMAIN | example.com | The plain domain name for which certificates will be generated.  The configured zone must match this.  The request will be for a certificate that's valid for example.com and *.example.com |
-| _PROXY_NAME | my-ssl-target-proxy | The name of the https proxy, by default this will be `[https-loadbalancer-name]-target-proxy` |
+| _FRONT_END_NAME_IPV4 | public-example-com-ipv4 | The name of the load balancer front-end for IP version 4, leave empty if not used |
+| _FRONT_END_NAME_IPV6 | public-example-com-ipv6 | The name of the load balancer front-end for IP version 6, leave empty if not used |
+| _SA_KEY_FILE | sa-certbot.json | Service account created to allow CertBot access to DNS zones, placed in this repostory |
 
 If all works well, you should have a new certificate on your load-balancer after having run the trigger for the first time.  
 The certificates will follow the naming pattern `zone-tld-certificate-serial` where any dots in the domain are replaced with dashes.  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ You'll need a certificate pair in order to create the load-balancer. A self-sign
 1. Create a Cloud DNS Zone  
 This needs to be properly registered with your registar.
 1. Grant `cloudbuild` IAM Role permissions  
-As Cloud Build will be interacting with the load-balancer and Cloud DNS, the cloudbuild account needs permissiosn to do so.  
+As Cloud Build will be interacting with the load-balancer and Cloud DNS, the cloudbuild account needs permissions to do so.
+1. Grant CertBot permissions to modidfy DNS records  
 1. Setup a Cloud Build Trigger
 
 ### Create an HTTPS Load-balancer
@@ -39,6 +40,7 @@ To allow cloud build to modify the loadbalancer configuration, create the follow
 
 Role: LoadBalancer certificate updates
 ```
+compute.forwardingRules.list
 compute.globalOperations.get
 compute.sslCertificates.create
 compute.sslCertificates.get
@@ -47,8 +49,12 @@ compute.targetHttpsProxies.get
 compute.targetHttpsProxies.list
 compute.targetHttpsProxies.setSslCertificates
 ```
+You can do this in the console under IAM & Admin > Roles [here](https://console.cloud.google.com/iam-admin/roles)  
+Add your new custom role to the cloudbuild member.
 
+### Grant CertBot permissions to modify DNS records
 In order to (separately) allow CertBot to alter the zone files in the process of DNS validation, we'll need the following addional role.
+
 Role: CertBot DNS ownership validation
 ```
 dns.changes.create
@@ -60,15 +66,10 @@ dns.resourceRecordSets.list
 dns.resourceRecordSets.update
 ```
 While we should be able to just add the above role to the cloud build service account as well, a bug somewhere makes CertBot insensitve to such additions.
-Instead we'll need to provide CertBot with an service account key explicitly, thoudh a json file.
+Instead we'll need to provide CertBot with an service account key explicitly, though a json file.
 So, create a new service account, for example 'sa-certbot', and grant it the above role. Also generate a json key for it, this is what we'll use. 
 The easiest way to provide the build system access to the key (security alert) is to include the json file directly into the (cloned) repository.
 Note that this is a workaround, that may no longer be necessary in the near future, as the CertBot team could solve the 'insensitivity'.
-
-You can do this in the console under IAM & Admin > Roles [here](https://console.cloud.google.com/iam-admin/roles)  
-Add your new custom role to the cloudbuild member.
-
-> Note: I think this is the minimal list, though there may be a few superfluous entries here.
 
 ### Setup a Cloud Build Trigger
 In the console under Cloud Build > Build Triggers [here](https://console.cloud.google.com/cloud-build/triggers), create a new trigger.  

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,7 @@ steps:
   entrypoint: "./gcp-le-renew.sh"
   args: [
     "certonly",
+    "--dns-google-credentials", "${_SA_KEY_FILE}",
     "--agree-tos", "-m", "${_EMAIL}",
     "--non-interactive",
     "--dns-google",
@@ -23,5 +24,6 @@ steps:
   entrypoint: "./gcp-ssl-update.sh"
   args: [
     "${_DOMAIN}",
-    "${_PROXY_NAME}"
+    "${_FRONT_END_NAME_IPV4}",
+    "${_FRONT_END_NAME_IPV6}"
   ]

--- a/gcp-ssl-update.sh
+++ b/gcp-ssl-update.sh
@@ -13,19 +13,45 @@ NAME=`echo $DOMAIN-$SERIAL | sed 's/\./-/g'`
 # Join array by delimiter - see https://stackoverflow.com/a/17841619/2242975
 function join_by { local IFS="$1"; shift; echo "$*"; }
 
-# Create a new ssl-certificate entry
-gcloud compute ssl-certificates create $NAME --certificate=./live/$DOMAIN/fullchain.pem --private-key=./live/$DOMAIN/privkey.pem
+if `gcloud compute ssl-certificates list | grep $SERIAL`; then
+   echo 'Certificate with this serial number was already processed, skipping loadbalancer update'
+else
+    # Create a new ssl-certificate entry
+    gcloud compute ssl-certificates create $NAME --certificate=./live/$DOMAIN/fullchain.pem --private-key=./live/$DOMAIN/privkey.pem
 
-# Get the most recent certificate for this domain (should be the one we just created)
-NEW_CERT=`gcloud compute ssl-certificates list --filter="name~'^$DOMAIN.*'" --limit 1 --sort-by ~creationTimestamp --format="value(name)"`
+    # Get the most recent certificate for this domain (should be the one we just created)
+    NEW_CERT=`gcloud compute ssl-certificates list --filter="name~'^$DOMAIN.*'" --limit 1 --sort-by ~creationTimestamp --format="value(name)"`
 
-# Get all certificates currently on the load-balancer
-EXISTING_CERTS=`gcloud compute target-https-proxies describe $PROXY_NAME --format="flattened(sslCertificates[].basename())" | awk '{print $2}'`
-# Strip any for this domain
-OTH_CERTS=`echo $EXISTING_CERTS | grep -v "^$DOMAIN" || true`
+    if [[! -z $FRONT_END_NAME_IPV4]]; then
+        echo 'Updating IPV4 forwarding leg'
 
-# Add the new cert plus all other domains, to make a comma-separated list of all certs to use
-ALL_CERTS=`join_by , $NEW_CERT $OTH_CERTS`
+        `PROXY_IPV4 = `gcloud beta compute forwarding-rules list --filter="name~$FRONT_END_NAME_IPV4" --format="value(target.scope())"`
 
-# Set the certificate list on the load-balancer
-gcloud compute target-https-proxies update $PROXY_NAME --ssl-certificates=$ALL_CERTS
+        # Get all certificates currently on the load-balancer
+        EXISTING_CERTS_IPV4=`gcloud compute target-https-proxies describe $PROXY_IPV4 --format="flattened(sslCertificates[].basename())" | awk '{print $2}'`
+        # Strip any for this domain
+        OTH_CERTS_IPV4=`echo $EXISTING_CERTS_IPV4 | grep -v "^$DOMAIN" || true`
+
+        # Add the new cert plus all other domains, to make a comma-separated list of all certs to use
+        ALL_CERTS_IPV4=`join_by , $NEW_CERT $OTH_CERTS_IPV4`
+
+        # Set the certificate list on the load-balancer
+        gcloud compute target-https-proxies update $PROXY_IPV4 --ssl-certificates=$ALL_CERTS_IPV4
+    fi
+
+    if [[! -z $FRONT_END_NAME_IPV6]]; then
+       echo 'Updating IPV6 forwarding leg'
+       
+        `PROXY_IPV6 = `gcloud beta compute forwarding-rules list --filter="name~$FRONT_END_NAME_IPV6" --format="value(target.scope())"`
+
+        # Get all certificates currently on the load-balancer
+        EXISTING_CERTS_IPV6=`gcloud compute target-https-proxies describe $PROXY_IPV6 --format="flattened(sslCertificates[].basename())" | awk '{print $2}'`
+        # Strip any for this domain
+        OTH_CERTS_IPV6=`echo $EXISTING_CERTS_IPV6 | grep -v "^$DOMAIN" || true`
+
+        # Add the new cert plus all other domains, to make a comma-separated list of all certs to use
+        ALL_CERTS_IPV6=`join_by , $NEW_CERT $OTH_CERTS_IPV6`
+
+        # Set the certificate list on the load-balancer
+        gcloud compute target-https-proxies update $PROXY_IPV6 --ssl-certificates=$ALL_CERTS_IPV6
+    fi


### PR DESCRIPTION
Dear initiator,

I made several updates:
Split the permissions needed into two sets, while it does slightly complicate the setup, it does provide additional robustness and simultaneously works around a CertBot issue.
Replaced the loadbalancer name lookup with front-end name lookup, to support situations where both IPv4 and IPv6 front-ends need to be updated.
Introduced a condition that prevents the 'certificate already exists' error when the script is run twice. It now just skips loadbalancer configuration if the serial number was already used to create a certificate on GCP.

With kind regards,
Walter Snel
